### PR TITLE
Fix near-midnight versions with RegEx

### DIFF
--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const write = require("write");
 const prependFile = require("prepend-file");
 
-const version = moment(new Date()).tz("Europe/Stockholm").format("YY.DDD.kmm").replace(/^([0-9]{2}\.[0-9]{0,3}\.).*(24)([0-9]{1,2})$/g, "$1$3")
+const version = moment(new Date()).tz("Europe/Stockholm").format("YY.DDD.kmm").replace(/^([0-9]{2}\.[0-9]{0,3}\.).*(24)([0-9]{1,2})$/g, "$1$3").replace(/\.0+?/g, ".")
 const header = `/* ==UserStyle==
 @name			SweClockers Dark
 @description	A modern dark theme for SweClockers


### PR DESCRIPTION
[Stylus](https://github.com/openstyles/stylus/) (or [UserCSS](https://github.com/openstyles/stylus/wiki/UserCSS) spec?) only accepts [SemVer (Semantic)](https://semver.org/) versions but we use a sort of Calendar Versioning here. [The RegEx Stylus uses](https://regex101.com/r/Ly7O1x/3/) that checks for SemVer compatibility doesn't allow for leading zeroes.

I implemented the following RegEx: `\.0+?`, this basically check for any zeroes directly following a period and removes them.

| Clock | Previously | Now |
| ----- | ---------- | --- |
| 00:05 | 20.317.05 | 20.317.5 |