### PR TITLE
Better local enviroment

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,16 @@ If you would like to contribute to this repository, please...
 
 5. Modify `src/sweclockers-dark.styl`, it's the file that GitHub Actions uses to generate the final ones.
 
-### Live editing
+### Live editing methods
 
 This project uses [`browser-sync`](https://www.npmjs.com/package/browser-sync) to inject the generated `.css` file into your browser.
 
-You can run `npm run compile`/`npm run compile-windows` for it to generate all the files once, this is primarily used by the GitHub Actions script.
+#### Editing using a single script (Recommended)
+You can get up and running by simply executing the command `npm run local`.
 
-Alternatively (**recommended**), you can run `npm run watch` and it will create the `.css` file specifically and always recreate it when you edit `src/sweclockers-dark.styl`
+This uses gulp to start the browser sync and in the same script also watch and generate changes done to `src/sweclockers-dark.styl`.
 
-To start the `browser-sync` script, run `npm run local` and it will inject the now generated `dist/sweclockers-dark.css`. You _should_ now be able to see changes live at `https://localhost:3000`.
+#### Generate and run server seperately
+To generate `dist/sweclockers-dark.css` file once, run `npm run stylus`, if you want it to generate the file every time changes occur to `src/sweclockers-dark.styl`, run `npm run stylus-watch`.
 
-_**Note**: I'm looking at ways of combining the above into a single script but for now it'll require two terminals._
+You can run the `browser-sync` script with `npm run browser-sync` and it will inject the `dist/sweclockers-dark.css` file onto a proxied version of `https://www.sweclockers.com/` .

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,50 @@
 			"license": "MPL-2.0",
 			"devDependencies": {
 				"browser-sync": "^2.26.13",
+				"del": "^6.0.0",
 				"gulp": "^4.0.2",
+				"gulp-stylus": "^2.7.0",
 				"moment-timezone": "^0.5.31",
 				"prepend-file": "^2.0.0",
 				"prettier": "2.1.2",
 				"stylus": "^0.54.8",
 				"stylus-supremacy": "^2.14.5",
 				"write": "^2.0.0"
+			}
+		},
+		"node_modules/@nodelib/fs.scandir": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.stat": "2.0.3",
+				"run-parallel": "^1.1.9"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.stat": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@nodelib/fs.walk": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.scandir": "2.1.3",
+				"fastq": "^1.6.0"
+			},
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/accepts": {
@@ -28,6 +65,37 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/accord": {
+			"version": "0.26.4",
+			"resolved": "https://registry.npmjs.org/accord/-/accord-0.26.4.tgz",
+			"integrity": "sha1-/EyNPrq0BqB8sogZuFllHESpLoA=",
+			"dev": true,
+			"dependencies": {
+				"convert-source-map": "^1.2.0",
+				"glob": "^7.0.5",
+				"indx": "^0.2.3",
+				"lodash.clone": "^4.3.2",
+				"lodash.defaults": "^4.0.1",
+				"lodash.flatten": "^4.2.0",
+				"lodash.merge": "^4.4.0",
+				"lodash.partialright": "^4.1.4",
+				"lodash.pick": "^4.2.1",
+				"lodash.uniq": "^4.3.0",
+				"resolve": "^1.1.7",
+				"semver": "^5.3.0",
+				"uglify-js": "^2.7.0",
+				"when": "^3.7.7"
+			}
+		},
+		"node_modules/accord/node_modules/semver": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver"
 			}
 		},
 		"node_modules/add-filename-increment": {
@@ -48,6 +116,51 @@
 			"integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
 			"dev": true
 		},
+		"node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dev": true,
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/align-text": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"dev": true,
+			"dependencies": {
+				"kind-of": "^3.0.2",
+				"longest": "^1.0.1",
+				"repeat-string": "^1.5.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/align-text/node_modules/is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
+		},
+		"node_modules/align-text/node_modules/kind-of": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+			"dev": true,
+			"dependencies": {
+				"is-buffer": "^1.1.5"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/ansi-colors": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
@@ -60,10 +173,34 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/ansi-cyan": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+			"integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+			"dev": true,
+			"dependencies": {
+				"ansi-wrap": "0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/ansi-gray": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
 			"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+			"dev": true,
+			"dependencies": {
+				"ansi-wrap": "0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/ansi-red": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+			"integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
 			"dev": true,
 			"dependencies": {
 				"ansi-wrap": "0.1.0"
@@ -263,6 +400,15 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/array-union": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/array-unique": {
@@ -886,6 +1032,19 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/center-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"dev": true,
+			"dependencies": {
+				"align-text": "^0.1.3",
+				"lazy-cache": "^1.0.3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/chalk": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -1017,6 +1176,15 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/cliui": {
@@ -1381,6 +1549,28 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/del": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+			"integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+			"dev": true,
+			"dependencies": {
+				"globby": "^11.0.1",
+				"graceful-fs": "^4.2.4",
+				"is-glob": "^4.0.1",
+				"is-path-cwd": "^2.2.0",
+				"is-path-inside": "^3.0.2",
+				"p-map": "^4.0.0",
+				"rimraf": "^3.0.2",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -1415,6 +1605,27 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/dir-glob": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dev": true,
+			"dependencies": {
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/dir-glob/node_modules/path-type": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/dlv": {
@@ -1913,11 +2124,37 @@
 				"node": ">= 0.10"
 			}
 		},
+		"node_modules/fast-glob": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+			"integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+			"dev": true,
+			"dependencies": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.0",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.2",
+				"picomatch": "^2.2.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/fast-levenshtein": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz",
 			"integrity": "sha1-5qdUzI8V5YmHqpy9J69m/W9OWvk=",
 			"dev": true
+		},
+		"node_modules/fastq": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+			"integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
+			"dev": true,
+			"dependencies": {
+				"reusify": "^1.0.4"
+			}
 		},
 		"node_modules/file-uri-to-path": {
 			"version": "1.0.0",
@@ -2702,6 +2939,26 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/globby": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+			"integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+			"dev": true,
+			"dependencies": {
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.1.1",
+				"ignore": "^5.1.4",
+				"merge2": "^1.3.0",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/glogg": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
@@ -2817,6 +3074,44 @@
 			"dependencies": {
 				"camelcase": "^3.0.0",
 				"object.assign": "^4.1.0"
+			}
+		},
+		"node_modules/gulp-stylus": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/gulp-stylus/-/gulp-stylus-2.7.0.tgz",
+			"integrity": "sha512-LlneLeHcaRBaEqxwo5YCirpsfkR7uleQ4pHXW8IE2ZeA6M3jpgI90+zQ6SptMTSWr1RSQW3WYFZVA3P0coUojw==",
+			"dev": true,
+			"dependencies": {
+				"accord": "^0.26.3",
+				"lodash.assign": "^3.2.0",
+				"plugin-error": "^0.1.2",
+				"replace-ext": "0.0.1",
+				"stylus": "^0.54.0",
+				"through2": "^2.0.0",
+				"vinyl-sourcemaps-apply": "^0.2.0"
+			},
+			"engines": {
+				"node": ">= 4.2.0"
+			}
+		},
+		"node_modules/gulp-stylus/node_modules/lodash.assign": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+			"integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+			"dev": true,
+			"dependencies": {
+				"lodash._baseassign": "^3.0.0",
+				"lodash._createassigner": "^3.0.0",
+				"lodash.keys": "^3.0.0"
+			}
+		},
+		"node_modules/gulp-stylus/node_modules/replace-ext": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/gulplog": {
@@ -3020,6 +3315,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/ignore": {
+			"version": "5.1.8",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+			"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/immutable": {
 			"version": "3.8.2",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
@@ -3029,10 +3333,25 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/indexof": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
 			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+			"dev": true
+		},
+		"node_modules/indx": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz",
+			"integrity": "sha1-Fdz1bunPZcAjTFE8J/vVgOcPvFA=",
 			"dev": true
 		},
 		"node_modules/inflight": {
@@ -3281,6 +3600,24 @@
 				"lodash.isfinite": "^3.3.2"
 			}
 		},
+		"node_modules/is-path-cwd": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+			"integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/is-path-inside": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+			"integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -3452,6 +3789,15 @@
 			},
 			"engines": {
 				"node": ">= 0.10"
+			}
+		},
+		"node_modules/lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/lazystream": {
@@ -3785,10 +4131,61 @@
 			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
 			"dev": true
 		},
+		"node_modules/lodash._baseassign": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+			"dev": true,
+			"dependencies": {
+				"lodash._basecopy": "^3.0.0",
+				"lodash.keys": "^3.0.0"
+			}
+		},
+		"node_modules/lodash._basecopy": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+			"dev": true
+		},
+		"node_modules/lodash._bindcallback": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+			"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+			"dev": true
+		},
+		"node_modules/lodash._createassigner": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+			"integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+			"dev": true,
+			"dependencies": {
+				"lodash._bindcallback": "^3.0.0",
+				"lodash._isiterateecall": "^3.0.0",
+				"lodash.restparam": "^3.0.0"
+			}
+		},
+		"node_modules/lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+			"dev": true
+		},
+		"node_modules/lodash._isiterateecall": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+			"dev": true
+		},
 		"node_modules/lodash.assign": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
 			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+			"dev": true
+		},
+		"node_modules/lodash.clone": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+			"integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
 			"dev": true
 		},
 		"node_modules/lodash.defaults": {
@@ -3797,11 +4194,79 @@
 			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
 			"dev": true
 		},
+		"node_modules/lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+			"dev": true
+		},
+		"node_modules/lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+			"dev": true
+		},
+		"node_modules/lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+			"dev": true
+		},
 		"node_modules/lodash.isfinite": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
 			"integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
 			"dev": true
+		},
+		"node_modules/lodash.keys": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"dev": true,
+			"dependencies": {
+				"lodash._getnative": "^3.0.0",
+				"lodash.isarguments": "^3.0.0",
+				"lodash.isarray": "^3.0.0"
+			}
+		},
+		"node_modules/lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true
+		},
+		"node_modules/lodash.partialright": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/lodash.partialright/-/lodash.partialright-4.2.1.tgz",
+			"integrity": "sha1-ATDYDoM2MmTUAHTzKbij56ihzEs=",
+			"dev": true
+		},
+		"node_modules/lodash.pick": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+			"integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+			"dev": true
+		},
+		"node_modules/lodash.restparam": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+			"dev": true
+		},
+		"node_modules/lodash.uniq": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+			"dev": true
+		},
+		"node_modules/longest": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
 		"node_modules/make-dir": {
 			"version": "3.1.0",
@@ -4045,6 +4510,15 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 8"
 			}
 		},
 		"node_modules/micromatch": {
@@ -4579,6 +5053,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/p-map": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+			"dev": true,
+			"dependencies": {
+				"aggregate-error": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -4783,6 +5272,74 @@
 				"object-assign": "^4.0.1",
 				"symbol": "^0.2.1"
 			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/plugin-error": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+			"integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+			"dev": true,
+			"dependencies": {
+				"ansi-cyan": "^0.1.1",
+				"ansi-red": "^0.1.1",
+				"arr-diff": "^1.0.1",
+				"arr-union": "^2.0.1",
+				"extend-shallow": "^1.1.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/plugin-error/node_modules/arr-diff": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+			"integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+			"dev": true,
+			"dependencies": {
+				"arr-flatten": "^1.0.1",
+				"array-slice": "^0.2.3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/plugin-error/node_modules/arr-union": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+			"integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/plugin-error/node_modules/array-slice": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+			"integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/plugin-error/node_modules/extend-shallow": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+			"integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+			"dev": true,
+			"dependencies": {
+				"kind-of": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/plugin-error/node_modules/kind-of": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+			"integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5175,6 +5732,63 @@
 				"node": ">=0.12"
 			}
 		},
+		"node_modules/reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true,
+			"engines": {
+				"iojs": ">=1.0.0",
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/right-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"dev": true,
+			"dependencies": {
+				"align-text": "^0.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/run-parallel": {
+			"version": "1.1.10",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+			"integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
 		"node_modules/rx": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
@@ -5441,6 +6055,15 @@
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
 			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
 			"dev": true
+		},
+		"node_modules/slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/snapdragon": {
 			"version": "0.8.2",
@@ -6362,6 +6985,83 @@
 				"node": "*"
 			}
 		},
+		"node_modules/uglify-js": {
+			"version": "2.8.29",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"dev": true,
+			"dependencies": {
+				"source-map": "~0.5.1",
+				"uglify-to-browserify": "~1.0.0",
+				"yargs": "~3.10.0"
+			},
+			"bin": {
+				"uglifyjs": "bin/uglifyjs"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			},
+			"optionalDependencies": {
+				"uglify-to-browserify": "~1.0.0"
+			}
+		},
+		"node_modules/uglify-js/node_modules/camelcase": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/uglify-js/node_modules/cliui": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+			"dev": true,
+			"dependencies": {
+				"center-align": "^0.1.1",
+				"right-align": "^0.1.1",
+				"wordwrap": "0.0.2"
+			}
+		},
+		"node_modules/uglify-js/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/uglify-js/node_modules/window-size": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/uglify-js/node_modules/yargs": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+			"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+			"dev": true,
+			"dependencies": {
+				"camelcase": "^1.0.2",
+				"cliui": "^2.1.0",
+				"decamelize": "^1.0.0",
+				"window-size": "0.1.0"
+			}
+		},
+		"node_modules/uglify-to-browserify": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"dev": true,
+			"optional": true
+		},
 		"node_modules/ultron": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -6681,6 +7381,24 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/vinyl-sourcemaps-apply": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+			"integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+			"dev": true,
+			"dependencies": {
+				"source-map": "^0.5.1"
+			}
+		},
+		"node_modules/vinyl-sourcemaps-apply/node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/vinyl/node_modules/clone": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -6698,6 +7416,12 @@
 			"dependencies": {
 				"defaults": "^1.0.3"
 			}
+		},
+		"node_modules/when": {
+			"version": "3.7.8",
+			"resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
+			"integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I=",
+			"dev": true
 		},
 		"node_modules/which": {
 			"version": "1.3.1",
@@ -6727,6 +7451,15 @@
 			},
 			"engines": {
 				"node": ">= 0.10.0"
+			}
+		},
+		"node_modules/wordwrap": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+			"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/wrap-ansi": {
@@ -6834,6 +7567,32 @@
 		}
 	},
 	"dependencies": {
+		"@nodelib/fs.scandir": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.stat": "2.0.3",
+				"run-parallel": "^1.1.9"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+			"dev": true
+		},
+		"@nodelib/fs.walk": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.scandir": "2.1.3",
+				"fastq": "^1.6.0"
+			}
+		},
 		"accepts": {
 			"version": "1.3.7",
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -6842,6 +7601,36 @@
 			"requires": {
 				"mime-types": "~2.1.24",
 				"negotiator": "0.6.2"
+			}
+		},
+		"accord": {
+			"version": "0.26.4",
+			"resolved": "https://registry.npmjs.org/accord/-/accord-0.26.4.tgz",
+			"integrity": "sha1-/EyNPrq0BqB8sogZuFllHESpLoA=",
+			"dev": true,
+			"requires": {
+				"convert-source-map": "^1.2.0",
+				"glob": "^7.0.5",
+				"indx": "^0.2.3",
+				"lodash.clone": "^4.3.2",
+				"lodash.defaults": "^4.0.1",
+				"lodash.flatten": "^4.2.0",
+				"lodash.merge": "^4.4.0",
+				"lodash.partialright": "^4.1.4",
+				"lodash.pick": "^4.2.1",
+				"lodash.uniq": "^4.3.0",
+				"resolve": "^1.1.7",
+				"semver": "^5.3.0",
+				"uglify-js": "^2.7.0",
+				"when": "^3.7.7"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				}
 			}
 		},
 		"add-filename-increment": {
@@ -6859,6 +7648,44 @@
 			"integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
 			"dev": true
 		},
+		"aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dev": true,
+			"requires": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			}
+		},
+		"align-text": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2",
+				"longest": "^1.0.1",
+				"repeat-string": "^1.5.2"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
 		"ansi-colors": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
@@ -6868,10 +7695,28 @@
 				"ansi-wrap": "^0.1.0"
 			}
 		},
+		"ansi-cyan": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+			"integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+			"dev": true,
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
+		},
 		"ansi-gray": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
 			"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+			"dev": true,
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
+		},
+		"ansi-red": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+			"integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
 			"dev": true,
 			"requires": {
 				"ansi-wrap": "0.1.0"
@@ -7022,6 +7867,12 @@
 				"get-value": "^2.0.6",
 				"kind-of": "^5.0.2"
 			}
+		},
+		"array-union": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"dev": true
 		},
 		"array-unique": {
 			"version": "0.3.2",
@@ -7526,6 +8377,16 @@
 			"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
 			"dev": true
 		},
+		"center-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+			"dev": true,
+			"requires": {
+				"align-text": "^0.1.3",
+				"lazy-cache": "^1.0.3"
+			}
+		},
 		"chalk": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -7634,6 +8495,12 @@
 					}
 				}
 			}
+		},
+		"clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"dev": true
 		},
 		"cliui": {
 			"version": "3.2.0",
@@ -7944,6 +8811,22 @@
 				"isobject": "^3.0.1"
 			}
 		},
+		"del": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
+			"integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
+			"dev": true,
+			"requires": {
+				"globby": "^11.0.1",
+				"graceful-fs": "^4.2.4",
+				"is-glob": "^4.0.1",
+				"is-path-cwd": "^2.2.0",
+				"is-path-inside": "^3.0.2",
+				"p-map": "^4.0.0",
+				"rimraf": "^3.0.2",
+				"slash": "^3.0.0"
+			}
+		},
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -7967,6 +8850,23 @@
 			"resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
 			"integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
 			"dev": true
+		},
+		"dir-glob": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dev": true,
+			"requires": {
+				"path-type": "^4.0.0"
+			},
+			"dependencies": {
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+					"dev": true
+				}
+			}
 		},
 		"dlv": {
 			"version": "1.1.3",
@@ -8403,11 +9303,34 @@
 				"time-stamp": "^1.0.0"
 			}
 		},
+		"fast-glob": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+			"integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+			"dev": true,
+			"requires": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.0",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.2",
+				"picomatch": "^2.2.1"
+			}
+		},
 		"fast-levenshtein": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz",
 			"integrity": "sha1-5qdUzI8V5YmHqpy9J69m/W9OWvk=",
 			"dev": true
+		},
+		"fastq": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+			"integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
+			"dev": true,
+			"requires": {
+				"reusify": "^1.0.4"
+			}
 		},
 		"file-uri-to-path": {
 			"version": "1.0.0",
@@ -9047,6 +9970,20 @@
 				"which": "^1.2.14"
 			}
 		},
+		"globby": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+			"integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+			"dev": true,
+			"requires": {
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.1.1",
+				"ignore": "^5.1.4",
+				"merge2": "^1.3.0",
+				"slash": "^3.0.0"
+			}
+		},
 		"glogg": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
@@ -9148,6 +10085,40 @@
 						"camelcase": "^3.0.0",
 						"object.assign": "^4.1.0"
 					}
+				}
+			}
+		},
+		"gulp-stylus": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/gulp-stylus/-/gulp-stylus-2.7.0.tgz",
+			"integrity": "sha512-LlneLeHcaRBaEqxwo5YCirpsfkR7uleQ4pHXW8IE2ZeA6M3jpgI90+zQ6SptMTSWr1RSQW3WYFZVA3P0coUojw==",
+			"dev": true,
+			"requires": {
+				"accord": "^0.26.3",
+				"lodash.assign": "^3.2.0",
+				"plugin-error": "^0.1.2",
+				"replace-ext": "0.0.1",
+				"stylus": "^0.54.0",
+				"through2": "^2.0.0",
+				"vinyl-sourcemaps-apply": "^0.2.0"
+			},
+			"dependencies": {
+				"lodash.assign": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+					"integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+					"dev": true,
+					"requires": {
+						"lodash._baseassign": "^3.0.0",
+						"lodash._createassigner": "^3.0.0",
+						"lodash.keys": "^3.0.0"
+					}
+				},
+				"replace-ext": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+					"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+					"dev": true
 				}
 			}
 		},
@@ -9313,16 +10284,34 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
+		"ignore": {
+			"version": "5.1.8",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+			"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+			"dev": true
+		},
 		"immutable": {
 			"version": "3.8.2",
 			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
 			"integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
 			"dev": true
 		},
+		"indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true
+		},
 		"indexof": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
 			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+			"dev": true
+		},
+		"indx": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz",
+			"integrity": "sha1-Fdz1bunPZcAjTFE8J/vVgOcPvFA=",
 			"dev": true
 		},
 		"inflight": {
@@ -9506,6 +10495,18 @@
 				"lodash.isfinite": "^3.3.2"
 			}
 		},
+		"is-path-cwd": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+			"integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+			"dev": true
+		},
+		"is-path-inside": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
+			"integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+			"dev": true
+		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -9636,6 +10637,12 @@
 				"default-resolution": "^2.0.0",
 				"es6-weak-map": "^2.0.1"
 			}
+		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true
 		},
 		"lazystream": {
 			"version": "1.0.0",
@@ -9913,10 +10920,61 @@
 			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
 			"dev": true
 		},
+		"lodash._baseassign": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+			"dev": true,
+			"requires": {
+				"lodash._basecopy": "^3.0.0",
+				"lodash.keys": "^3.0.0"
+			}
+		},
+		"lodash._basecopy": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+			"dev": true
+		},
+		"lodash._bindcallback": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+			"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+			"dev": true
+		},
+		"lodash._createassigner": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+			"integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+			"dev": true,
+			"requires": {
+				"lodash._bindcallback": "^3.0.0",
+				"lodash._isiterateecall": "^3.0.0",
+				"lodash.restparam": "^3.0.0"
+			}
+		},
+		"lodash._getnative": {
+			"version": "3.9.1",
+			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+			"dev": true
+		},
+		"lodash._isiterateecall": {
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+			"dev": true
+		},
 		"lodash.assign": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
 			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+			"dev": true
+		},
+		"lodash.clone": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+			"integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
 			"dev": true
 		},
 		"lodash.defaults": {
@@ -9925,10 +10983,75 @@
 			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
 			"dev": true
 		},
+		"lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+			"dev": true
+		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+			"dev": true
+		},
+		"lodash.isarray": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+			"dev": true
+		},
 		"lodash.isfinite": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
 			"integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=",
+			"dev": true
+		},
+		"lodash.keys": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+			"dev": true,
+			"requires": {
+				"lodash._getnative": "^3.0.0",
+				"lodash.isarguments": "^3.0.0",
+				"lodash.isarray": "^3.0.0"
+			}
+		},
+		"lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+			"dev": true
+		},
+		"lodash.partialright": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/lodash.partialright/-/lodash.partialright-4.2.1.tgz",
+			"integrity": "sha1-ATDYDoM2MmTUAHTzKbij56ihzEs=",
+			"dev": true
+		},
+		"lodash.pick": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+			"integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+			"dev": true
+		},
+		"lodash.restparam": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+			"dev": true
+		},
+		"lodash.uniq": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+			"dev": true
+		},
+		"longest": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+			"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
 			"dev": true
 		},
 		"make-dir": {
@@ -10127,6 +11250,12 @@
 					}
 				}
 			}
+		},
+		"merge2": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+			"dev": true
 		},
 		"micromatch": {
 			"version": "4.0.2",
@@ -10545,6 +11674,15 @@
 				"p-limit": "^2.2.0"
 			}
 		},
+		"p-map": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+			"dev": true,
+			"requires": {
+				"aggregate-error": "^3.0.0"
+			}
+		},
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -10697,6 +11835,58 @@
 				"load-json-file": "^1.1.0",
 				"object-assign": "^4.0.1",
 				"symbol": "^0.2.1"
+			}
+		},
+		"plugin-error": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+			"integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+			"dev": true,
+			"requires": {
+				"ansi-cyan": "^0.1.1",
+				"ansi-red": "^0.1.1",
+				"arr-diff": "^1.0.1",
+				"arr-union": "^2.0.1",
+				"extend-shallow": "^1.1.2"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+					"integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.0.1",
+						"array-slice": "^0.2.3"
+					}
+				},
+				"arr-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+					"integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+					"dev": true
+				},
+				"array-slice": {
+					"version": "0.2.3",
+					"resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+					"integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+					"dev": true
+				},
+				"extend-shallow": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+					"integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^1.1.0"
+					}
+				},
+				"kind-of": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+					"integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+					"dev": true
+				}
 			}
 		},
 		"portscanner": {
@@ -11012,6 +12202,36 @@
 			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
 			"dev": true
 		},
+		"reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true
+		},
+		"right-align": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+			"dev": true,
+			"requires": {
+				"align-text": "^0.1.1"
+			}
+		},
+		"rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
+		"run-parallel": {
+			"version": "1.1.10",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+			"integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
+			"dev": true
+		},
 		"rx": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
@@ -11244,6 +12464,12 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
 			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+			"dev": true
+		},
+		"slash": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true
 		},
 		"snapdragon": {
@@ -12039,6 +13265,67 @@
 			"integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==",
 			"dev": true
 		},
+		"uglify-js": {
+			"version": "2.8.29",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"dev": true,
+			"requires": {
+				"source-map": "~0.5.1",
+				"uglify-to-browserify": "~1.0.0",
+				"yargs": "~3.10.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+					"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+					"dev": true
+				},
+				"cliui": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+					"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+					"dev": true,
+					"requires": {
+						"center-align": "^0.1.1",
+						"right-align": "^0.1.1",
+						"wordwrap": "0.0.2"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"window-size": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+					"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+					"dev": true
+				},
+				"yargs": {
+					"version": "3.10.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+					"dev": true,
+					"requires": {
+						"camelcase": "^1.0.2",
+						"cliui": "^2.1.0",
+						"decamelize": "^1.0.0",
+						"window-size": "0.1.0"
+					}
+				}
+			}
+		},
+		"uglify-to-browserify": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"dev": true,
+			"optional": true
+		},
 		"ultron": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -12306,6 +13593,23 @@
 				}
 			}
 		},
+		"vinyl-sourcemaps-apply": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+			"integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+			"dev": true,
+			"requires": {
+				"source-map": "^0.5.1"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
 		"wcwidth": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -12314,6 +13618,12 @@
 			"requires": {
 				"defaults": "^1.0.3"
 			}
+		},
+		"when": {
+			"version": "3.7.8",
+			"resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
+			"integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I=",
+			"dev": true
 		},
 		"which": {
 			"version": "1.3.1",
@@ -12334,6 +13644,12 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
 			"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+			"dev": true
+		},
+		"wordwrap": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+			"integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
 			"dev": true
 		},
 		"wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
 	"name": "SweClockers-Dark",
 	"description": "A modern dark theme for SweClockers",
 	"scripts": {
-		"compile": "npm run clean & stylus src/sweclockers-dark.styl -o dist/sweclockers-dark.css && node scripts/compile.js",
-		"compile-windows": "npm run clean-windows & stylus src/sweclockers-dark.styl -o dist/sweclockers-dark.css && node scripts/compile.js",
-		"clean": "rm -rf dist",
-		"clean-windows": "rmdir dist /s /q",
-		"watch": "stylus -w src/sweclockers-dark.styl -o dist/sweclockers-dark.css",
-		"local": "node scripts/local.js"
+		"compile": "npm run clean && stylus src/sweclockers-dark.styl -o dist/sweclockers-dark.css && node scripts/compile.js",
+		"local": "stylus src/sweclockers-dark.styl -o dist/sweclockers-dark.css && gulp --gulpfile scripts/local.js",
+		"clean": "node scripts/clean.js",
+		"stylus": "stylus src/sweclockers-dark.styl -o dist/sweclockers-dark.css",
+		"stylus-watch": "stylus -w src/sweclockers-dark.styl -o dist/sweclockers-dark.css",
+		"browser-sync": "node scripts/browser-sync.js"
 	},
 	"repository": {
 		"type": "git",
@@ -21,7 +21,9 @@
 	"homepage": "https://github.com/Soitora/SweClockers-Dark#readme",
 	"devDependencies": {
 		"browser-sync": "^2.26.13",
+		"del": "^6.0.0",
 		"gulp": "^4.0.2",
+		"gulp-stylus": "^2.7.0",
 		"moment-timezone": "^0.5.31",
 		"prepend-file": "^2.0.0",
 		"prettier": "2.1.2",

--- a/scripts/browser-sync.js
+++ b/scripts/browser-sync.js
@@ -1,0 +1,15 @@
+const browserSync = require('browser-sync').create();
+
+browserSync.init({
+    proxy: "https://www.sweclockers.com",
+    serveStatic: ["dist"],
+    files: "dist/sweclockers-dark.css",
+    snippetOptions: {
+        rule: {
+            match: /<\/head>/i,
+            fn: function (snippet, match) {
+                return '<link rel="stylesheet" type="text/css" href="/sweclockers-dark.css"/>' + snippet + match;
+            }
+        }
+    }
+});

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -1,0 +1,4 @@
+const del = require('del');
+
+del.sync(["dist"]);
+console.log("Deleted the \"dist\" directory.")

--- a/scripts/local.js
+++ b/scripts/local.js
@@ -1,15 +1,28 @@
-const browserSync = require('browser-sync').create();
+const gulp = require("gulp");
+const stylus = require("gulp-stylus");
+const browserSync = require("browser-sync").create();
 
-browserSync.init({
-    proxy: "https://www.sweclockers.com",
-    serveStatic: ["dist"],
-    files: "dist/sweclockers-dark.css",
-    snippetOptions: {
-        rule: {
-            match: /<\/head>/i,
-            fn: function (snippet, match) {
-                return '<link rel="stylesheet" type="text/css" href="/sweclockers-dark.css"/>' + snippet + match;
-            }
-        }
-    }
+gulp.task('default', function (done) {
+	browserSync.init({
+		proxy: "https://www.sweclockers.com",
+		serveStatic: ["../dist"],
+		files: "../dist/sweclockers-dark.css",
+		snippetOptions: {
+			rule: {
+				match: /<\/head>/i,
+				fn: function (snippet, match) {
+					return `<link rel="stylesheet" type="text/css" href="/sweclockers-dark.css"/>` + snippet + match;
+				}
+			}
+		}
+	});
+	gulp.watch("../src/sweclockers-dark.styl", gulp.series("styl"));
+	done();
+});
+
+gulp.task("styl", function () {
+	return gulp.src("../src/sweclockers-dark.styl")
+		.pipe(stylus())
+		.pipe(gulp.dest("../dist/"))
+		.pipe(browserSync.reload({stream: true}));
 });


### PR DESCRIPTION
Continuation of what I felt was lacking after creating #7.
New documentation for scripts available at the new README.

`npm run compile`/`npm run clean` should now work universally instead of requiring a seperate script for Windows.

### Deleted scripts
- `compile-windows`
- `clean-windows`

### Renamed scripts
- `local` -> `browser-sync`
- `watch` -> `stylus-watch`

### New scripts
- `local`
- `stylus`