### PR TITLE
Prevent PM link from being styled as red

### DIFF
--- a/src/sweclockers-dark.styl
+++ b/src/sweclockers-dark.styl
@@ -865,8 +865,10 @@ fieldset
 								background-color var-highlight
 						&:first-child svg
 							fill var-text-2
-						&:last-child svg
-							fill var-warning
+						&:last-child
+							a:not(.pm-link)
+								svg
+									fill var-warning
 				.bg-white
 					background-color var-on-background-2 !important
 					box-shadow var-box-shadow-inset


### PR DESCRIPTION
The PM button was being styled red as I had needed a `:last-child` rule. Fortunately the PM button had a unique class assigned and thus I was able to fix this easily.

Resolves #6